### PR TITLE
Separation from RPC-O

### DIFF
--- a/playbooks/archive-control-plane.yml
+++ b/playbooks/archive-control-plane.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: common-playbooks/register-openstack-release.yml
+
 - name: Get container hosts
   hosts: localhost
   connection: local
@@ -23,7 +25,7 @@
         _known_container_hosts: >
           {% set _var = [] -%}
           {% for item in groups['all_containers'] | default([]) -%}
-          {%   if item not in ['ceph_all','rsyslog_all','elasticsearch_all'] -%}
+          {%   if item not in ['ceph_all','rsyslog_all','elasticsearch_all','mons'] -%}
           {%     if hostvars[item]['physical_host'] | default(false) != item -%}
           {%       if _var.append(hostvars[item]['physical_host']) -%}
           {%       endif -%}
@@ -47,7 +49,7 @@
         state: directory
 
 - name: Archive container(s)
-  hosts: "{{ container_group|default('all_containers:!ceph_all:!rsyslog_all:!elasticsearch_all') }}"
+  hosts: "{{ container_group|default('all_containers:!ceph_all:!rsyslog_all:!elasticsearch_all:!mons') }}"
   gather_facts: false
   serial: '20%'
   user: root
@@ -74,8 +76,8 @@
         name: "{{ item }}"
         state: absent
       with_items:
-        - "/openstack/backup/control-plane/{{ rpc_release }}-{{ inventory_hostname }}_config.tgz"
-        - "/openstack/backup/control-plane/{{ rpc_release }}-{{ inventory_hostname }}.tar.tgz"
+        - "/openstack/backup/control-plane/{{ openstack_release }}-{{ inventory_hostname }}_config.tgz"
+        - "/openstack/backup/control-plane/{{ openstack_release }}-{{ inventory_hostname }}.tar.tgz"
       ignore_errors: True
       delegate_to: "{{ physical_host }}"
 
@@ -88,14 +90,14 @@
       delegate_to: "{{ physical_host }}"
 
     - name: Rename container archive
-      command: mv -f /openstack/backup/control-plane/{{ inventory_hostname }}.tar.tgz /openstack/backup/control-plane/{{ rpc_release }}-{{ inventory_hostname }}.tar.tgz
+      command: mv -f /openstack/backup/control-plane/{{ inventory_hostname }}.tar.tgz /openstack/backup/control-plane/{{ openstack_release }}-{{ inventory_hostname }}.tar.tgz
       args:
-        creates: "/openstack/backup/control-plane/{{ rpc_release }}-{{ inventory_hostname }}.tar.tgz"
+        creates: "/openstack/backup/control-plane/{{ openstack_release }}-{{ inventory_hostname }}.tar.tgz"
       delegate_to: "{{ physical_host }}"
 
     - name: Archive container configuration
       command: |
-        tar czf /openstack/backup/control-plane/{{ rpc_release }}-{{ inventory_hostname }}_config.tgz {{ container_config.results[0].stdout |replace('\n', ' ') }}
+        tar czf /openstack/backup/control-plane/{{ openstack_release }}-{{ inventory_hostname }}_config.tgz {{ container_config.results[0].stdout |replace('\n', ' ') }}
       args:
         chdir: "/var/lib/lxc/{{ item }}"
       with_items: "{{ inventory_hostname }}"
@@ -105,7 +107,7 @@
 
     - name: Remove temporary containers
       lxc_container:
-        name: "{{ rpc_release }}-{{ inventory_hostname }}"
+        name: "{{ openstack_release }}-{{ inventory_hostname }}"
         state: "absent"
       delegate_to: "{{ physical_host }}"
   vars:

--- a/playbooks/common-playbooks/register-openstack-release.yml
+++ b/playbooks/common-playbooks/register-openstack-release.yml
@@ -1,0 +1,54 @@
+---
+# Copyright 2019-Present, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Find /etc/openstack-release
+      stat:
+        path: /etc/openstack-release
+      ignore_errors: yes
+      register: osa_release_file
+
+    - name: Find /etc/rhosp-release
+      stat:
+        path: /etc/rhosp-release
+      ignore_errors: yes
+      register: osp_release_file
+
+    - name: Determine OSA version
+      shell: awk -F= '/^DISTRIB_RELEASE/ {print $2}' {{ osa_release_file.stat.path }} | tr -d \"\'
+      when:
+        - osa_release_file is defined
+        - osa_release_file.stat.exists |bool
+      register: osa_release_output
+
+    - name: Determine OSP version
+      shell: egrep -o '[0-9]+\.[0-9]+' {{ osa_release_file.stat.path }}
+      when:
+        - osp_release_file is defined
+        - osp_release_file.stat.exists |bool
+      register: osp_release_output
+
+    - name: Register openstack_release
+      set_fact:
+        openstack_release: "{{ osa_release_output is defined |ternary(osa_release_output.stdout,osp_release_output.stdout) |default('0.0.0') }}"
+        openstack_product: "{{ osa_release_output is defined |ternary('RPCO','OSP') |default('RPCO') }}"
+
+    - name: Print openstack_release version
+      debug: var=openstack_release
+
+  tags:
+    - always

--- a/playbooks/common-tasks/install-dependencies.yml
+++ b/playbooks/common-tasks/install-dependencies.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@
     group: "root"
     mode: "0755"
     state: "directory"
-  when: ops_pip_venv_enabled |bool
   tags:
    - always
 

--- a/playbooks/common-tasks/synchronize-file.yml
+++ b/playbooks/common-tasks/synchronize-file.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace US, Inc.
+# Copyright 2019-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Install pcommon
-  hosts: neutron_agents_container:shared-infra_hosts:utility_container
-  gather_facts: "{{ gather_facts | default(true) }}"
-  tasks:
-    - name: Deploy pccommon
-      copy:
-        src: "files/rpc-o-support/pccommon.sh"
-        dest: /root/pccommon.sh
-        mode: 0600
-  vars_files:
-    - "vars/main.yml"
+- name: Synchronize file object
+  synchronize:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "{{ item.mode }}"
+  with_items: "{{ synchronize_files |default({}) }}"

--- a/playbooks/configure-apt.yml
+++ b/playbooks/configure-apt.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Configure apt package manager
   hosts: hosts
+  environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"

--- a/playbooks/configure-bash-environment.yml
+++ b/playbooks/configure-bash-environment.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Configure bash environment on hosts
   hosts: hosts:utility_container
+  environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"

--- a/playbooks/configure-cpu-governor.yml
+++ b/playbooks/configure-cpu-governor.yml
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Configure Linux CPU governor
   hosts: hosts:mons:osds
+  environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   vars:
     governor: "{{ cpu_governor | default('performance') }}"

--- a/playbooks/configure-glance.yml
+++ b/playbooks/configure-glance.yml
@@ -15,49 +15,44 @@
 
 - include: "common-playbooks/register-openstack-release.yml"
 
-- name: Retrieve openrc
-  hosts: utility_container[0]
-  gather_facts: "{{ gather_facts | default(true) }}"
-  tasks:
-    - include: "common-tasks/synchronize-file.yml"
-
-  vars:
-    synchronize_files:
-       - src: "/root/openrc"
-         dest: "/root"
-         mode: "pull"
-
-  vars_files:
-    - "vars/main.yml"
-
-  tags:
-    - nova-default-flavor-setup
-
-- name: Configure settings for OpenStack Nova
+- name: OpenStack image setup
   hosts: localhost
   environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"
   tasks:
-    - name: Create flavors of nova VMs
+    - name: Download system image file
+      get_url:
+        url: "{{ item.url }}"
+        dest: "/var/tmp/os_image_{{ item.name }}"
+        timeout: 1200
+      with_items: "{{ openstack_images }}"
+
+    - name: Install system image
       environment:
         PYTHONHOME: "{{ ops_venv }}"
-      os_nova_flavor:
+      os_image:
         endpoint_type: internal
         cloud: default
         state: present
+        is_public: true
         name: "{{ item.name }}"
-        ram: "{{ item.ram }}"
-        vcpus: "{{ item.vcpus }}"
-        disk: "{{ item.disk }}"
-        swap: "{{ item.swap }}"
-        ephemeral: "{{ item.ephemeral }}"
-      with_items: "{{ openstack_vm_flavors }}"
+        filename: "/var/tmp/os_image_{{ item.name }}"
+        disk_format: "{{ item.format }}"
+        properties: "{{ item.properties | default(omit) }}"
+      with_items: "{{ openstack_images }}"
+
+    - name: Clean up temp file
+      file:
+        dest: "/var/tmp/os_image_{{ item.name }}"
+        state: absent
+      with_items: "{{ openstack_images }}"
 
   vars_files:
     - "vars/main.yml"
     - "vars/openstack-service-config.yml"
 
   tags:
-    - nova-default-flavor-setup
+    - glance-image-upload
+

--- a/playbooks/configure-hosts.yml
+++ b/playbooks/configure-hosts.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Configure hosts
   hosts: hosts
+  environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"

--- a/playbooks/configure-neutron.yml
+++ b/playbooks/configure-neutron.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Configure OpenStack Neutron
   hosts: utility_container[0]
+  environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"

--- a/playbooks/configure-spice-console.yml
+++ b/playbooks/configure-spice-console.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Update spice console
   hosts: nova_console
+  environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"

--- a/playbooks/gather-facts.yml
+++ b/playbooks/gather-facts.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/install-dell-server-monitoring.yml
+++ b/playbooks/install-dell-server-monitoring.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+- include: "common-playbooks/register-openstack-release.yml"
 
 - name: Install Dell server monitoring
   hosts: hosts:osds:mons

--- a/playbooks/install-holland-db-backup.yml
+++ b/playbooks/install-holland-db-backup.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+- include: "common-playbooks/register-openstack-release.yml"
 
 - name: Configure holland DB user
   hosts: galera[0]

--- a/playbooks/install-hp-server-monitoring.yml
+++ b/playbooks/install-hp-server-monitoring.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present, Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+- include: "common-playbooks/register-openstack-release.yml"
 
 - name: Install HP server monitoring
   hosts: hosts:osds:mons

--- a/playbooks/install-hw-raid-tools.yml
+++ b/playbooks/install-hw-raid-tools.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+- include: "common-playbooks/register-openstack-release.yml"
 
 - name: Install hwraid tools onto storage and swift object hosts
   hosts: storage_hosts:swift_obj

--- a/playbooks/install-sos-tool.yml
+++ b/playbooks/install-sos-tool.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2017-Present Rackspace Inc
+# Copyright 2017-Present, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+- include: "common-playbooks/register-openstack-release.yml"
 
 - name: Install the sos utility
   hosts: hosts

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -7,6 +7,7 @@
 - include: configure-hosts.yml
 - include: configure-neutron.yml
 - include: configure-nova.yml
+- include: configure-glance.yml
 - include: configure-spice-console.yml
 - include: install-holland-db-backup.yml
 - include: install-dell-server-monitoring.yml

--- a/playbooks/print-product-configuration.yml
+++ b/playbooks/print-product-configuration.yml
@@ -1,0 +1,41 @@
+---
+# Copyright 2019-Present, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: "common-playbooks/register-openstack-release.yml"
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Current OSA configuration {{ item }}
+      debug: var="{{ item }}"
+      with_items:
+        - internal_lb_vip_address
+        - external_lb_vip_address
+        - global_environment_variables
+        - neutron_provider_networks
+        - rpc_conn_pool_size
+        - rpc_response_timeout
+        - rpc_thread_pool_size
+        - neutron_api_workers
+        - galera_max_connections
+        - db_max_overflow
+        - db_max_pool_size
+        - db_pool_timeout
+        - memcached_connections
+        - rabbitmq_policies
+        - openstack_domain
+        - dhcp_domain
+        - openstack_service_publicuri_proto
+      when: openstack_product == "RPCO"

--- a/playbooks/support-key.yml
+++ b/playbooks/support-key.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Create RPC support key
   hosts: os-infra_hosts[0]
   gather_facts: "{{ gather_facts | default(true) }}"
@@ -57,7 +59,7 @@
     - name: Check for support keypair in nova
       shell: |
         . /root/openrc
-        {{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}/bin/nova keypair-list | grep rpc_support
+        {{ ops_venv }}/bin/nova keypair-list | grep rpc_support
       register: nova_support_key
       changed_when: false
       failed_when: false
@@ -65,7 +67,7 @@
     - name: Delete support keypair in nova
       shell: |
         . /root/openrc
-        {{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}/bin/nova keypair-delete rpc_support
+        {{ ops_venv }}/bin/nova keypair-delete rpc_support
       register: nova_support_key_delete
       changed_when: nova_support_key_delete.rc == 0
       failed_when: false
@@ -76,7 +78,7 @@
     - name: Add support key to nova
       shell: |
         . /root/openrc
-        {{ ops_pip_venv_enabled | bool | ternary(ops_venv, omit) }}/bin/nova keypair-add --pub-key /root/.ssh/rpc_support.pub rpc_support
+        {{ ops_venv }}/bin/nova keypair-add --pub-key /root/.ssh/rpc_support.pub rpc_support
       retries: 2
       delay: 10
       when: nova_support_key_delete|changed or nova_support_key.rc == 1

--- a/playbooks/swift-datacrusher.yml
+++ b/playbooks/swift-datacrusher.yml
@@ -1,5 +1,5 @@
 ---
-# 2017-Present, Bjoern Teipel <bjoern.teipel@rackspace.com>
+# Copyright 2017-Present, Rackspace US, Inc
 #
 # Play to tear down Swift data nodes
 #

--- a/playbooks/update-hp-firmware.yml
+++ b/playbooks/update-hp-firmware.yml
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: "common-playbooks/register-openstack-release.yml"
+
 - name: Install HP firmware update tool
   hosts: hosts:osds:mons:mgrs
   gather_facts: "{{ gather_facts | default(true) }}"
@@ -61,7 +63,7 @@
 
     - name: Execute HP firmware upgrade as background task
       command: |
-        {{ screen_binary.stdout }} -d -m -L -t "hp_firmware_update" bash -c "source {{ ops_pip_venv_enabled | bool | ternary(ops_venv + '/bin/activate', omit) }} || true; /usr/local/bin/update_hp_firmware.py -f {{ firmware_use_meltdown | default(false) | bool | ternary('--meltdown', '') }}"
+        {{ screen_binary.stdout }} -d -m -L -t "hp_firmware_update" bash -c "source {{ ops_venv + '/bin/activate' }} || true; /usr/local/bin/update_hp_firmware.py -f {{ firmware_use_meltdown | default(false) | bool | ternary('--meltdown', '') }}"
       changed_when: false
       when:
         - screen_binary |changed

--- a/playbooks/vars/holland.yml
+++ b/playbooks/vars/holland.yml
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ops_holland_venv_bin: "/openstack/venvs/holland-{{ rpc_release }}/bin"
-ops_holland_venv: "/openstack/venvs/holland-{{ rpc_release }}"
+ops_holland_venv_bin: "/openstack/venvs/holland-{{ openstack_release }}/bin"
+ops_holland_venv: "/openstack/venvs/holland-{{ openstack_release }}"
 
 ops_holland_repo_package_name: holland
 ops_holland_service_name: holland

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -17,6 +17,7 @@ ops_requires_pip_packages:
   - virtualenv
 
 ops_pip_dependencies:
+  - shade
   - python-openstackclient
   - python-neutronclient
 
@@ -51,12 +52,8 @@ ops_neutron_debug_packages:
   - ethtool
   - curl
 
-
-ops_venv: "/openstack/venvs/rcbops-{{ rpc_release }}"
-ops_venv_bin: "{{ ops_venv }}/bin"
-ops_pip_venv_enabled: True
-
-
+# All OPS tools are now installed inside a python venv
+ops_venv: "/openstack/venvs/rcbops-{{ openstack_release |default('0.0.0') }}"
 
 # kernel modules required on hosts
 ops_host_kernel_modules:

--- a/playbooks/vars/openstack-service-config.yml
+++ b/playbooks/vars/openstack-service-config.yml
@@ -1,0 +1,118 @@
+---
+
+openstack_vm_flavors:
+  - name: m1.micro
+    ram: 256
+    vcpus: 1
+    disk: 1
+    swap: 0
+    ephemeral: 0
+  - name: m1.tiny
+    ram: 512
+    vcpus: 1
+    disk: 1
+    swap: 0
+    ephemeral: 0
+  - name: m1.mini
+    ram: 1024
+    vcpus: 2
+    disk: 3
+    swap: 0
+    ephemeral: 0
+  - name: m1.small
+    ram: 2048
+    vcpus: 3
+    disk: 12
+    swap: 4
+    ephemeral: 4
+  - name: m1.medium
+    ram: 4096
+    vcpus: 6
+    disk: 60
+    swap: 4
+    ephemeral: 20
+  - name: m1.large
+    ram: 8192
+    vcpus: 12
+    disk: 300
+    swap: 4
+    ephemeral: 150
+  - name: m1.xlarge
+    ram: 16384
+    vcpus: 24
+    disk: 600
+    swap: 4
+    ephemeral: 256
+  - name: m1.heavy
+    ram: 32768
+    vcpus: 48
+    disk: 1200
+    swap: 4
+    ephemeral: 256
+
+openstack_images:
+  - name: CentOS 7
+    format: qcow2
+    url: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
+    properties:
+      hw_scsi_model: "virtio-scsi"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "kvm"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
+  - name: Cirros-0.4.0 (kvm)
+    format: qcow2
+    url: http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    properties:
+      hypervisor_type: "kvm"
+  - name: Cirros-0.4.0
+    format: qcow2
+    url: http://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img
+    properties:
+      hypervisor_type: "qemu"
+  - name: Debian 9
+    format: qcow2
+    url: http://cdimage.debian.org/cdimage/openstack/current-9/debian-9-openstack-amd64.qcow2
+    properties:
+      hw_scsi_model: "virtio-scsi"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "kvm"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
+  - name: OpenSuse Leap 42.3
+    format: qcow2
+    url: http://download.opensuse.org/repositories/Cloud:/Images:/Leap_42.3/images/openSUSE-Leap-42.3-OpenStack.x86_64.qcow2
+    properties:
+      hw_scsi_model: "virtio-scsi"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "kvm"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
+  - name: Ubuntu 16.04
+    format: qcow2
+    url: http://uec-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
+    properties:
+      hw_scsi_model: "virtio-scsi"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "kvm"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"
+  - name: Ubuntu 18.04
+    format: qcow2
+    url: http://uec-images.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-cloudimg-amd64.img
+    properties:
+      hw_scsi_model: "virtio-scsi"
+      hw_disk_bus: "scsi"
+      hw_vif_multiqueue_enabled: "true"
+      hw_qemu_guest_agent: "yes"
+      hypervisor_type: "kvm"
+      os_require_quiesce: "yes"
+      img_config_drive: "optional"


### PR DESCRIPTION
Changes are made to run on stock OSA releases and dependency
on RPC-O specific overrides are removed while functionality
to install glance images are moved into this repo