### PR TITLE
Replace os-infra_hosts group

### DIFF
--- a/playbooks/files/rpc-o-support/rebuild-rabbitmq-container.sh
+++ b/playbooks/files/rpc-o-support/rebuild-rabbitmq-container.sh
@@ -15,7 +15,7 @@ for i in $(seq 1 20); do
 done
 
 openstack-ansible -e container_group="rabbit_mq_container" -e force_containers_destroy="yes" -e force_containers_data_destroy="yes" lxc-containers-destroy.yml 
-openstack-ansible lxc-containers-create.yml --limit rabbit_mq_container:os-infra_hosts:infra_hosts
+openstack-ansible lxc-containers-create.yml --limit rabbit_mq_container:shared-infra_hosts:infra_hosts
 openstack-ansible rabbitmq-install.yml
 
 # Re-add OpenStack rabbitmq users

--- a/playbooks/support-key.yml
+++ b/playbooks/support-key.yml
@@ -16,7 +16,7 @@
 - include: "common-playbooks/register-openstack-release.yml"
 
 - name: Create RPC support key
-  hosts: os-infra_hosts[0]
+  hosts: shared-infra_hosts[0]
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"
@@ -86,7 +86,7 @@
     - "vars/main.yml"
 
 - name: Get local RPC support pubkey hash
-  hosts: os-infra_hosts:utility_container:neutron_agents_container
+  hosts: shared-infra_hosts:utility_container:neutron_agents_container
   gather_facts: "false"
   tasks:
     - name: Retreive local support SSH key stats
@@ -97,7 +97,7 @@
       register: local_support_key_check
 
 - name: Distribute RPC support key
-  hosts: os-infra_hosts[1:999]:utility_container:neutron_agents_container
+  hosts: shared-infra_hosts[1:999]:utility_container:neutron_agents_container
   gather_facts: "false"
   tasks:
     - name: Distribute support SSH key for cluster operations
@@ -109,12 +109,12 @@
         mode: "0600"
       with_items:
         - dest: "/root/.ssh/rpc_support"
-          content: "{{ hostvars[groups['os-infra_hosts'][0]]['support_key'].content | b64decode }}"
+          content: "{{ hostvars[groups['shared-infra_hosts'][0]]['support_key'].content | b64decode }}"
         - dest: "/root/.ssh/rpc_support.pub"
-          content: "{{ hostvars[groups['os-infra_hosts'][0]]['support_pub_key'].content | b64decode }}"
+          content: "{{ hostvars[groups['shared-infra_hosts'][0]]['support_pub_key'].content | b64decode }}"
       when:
-        - hostvars[groups['os-infra_hosts'][0]]['support_pub_key'].content |default('') |length > 64
-        - hostvars[groups['os-infra_hosts'][0]]['support_pub_key'].content |default('') |length > 64
-        - hostvars[groups['os-infra_hosts'][0]]['support_key'].content |b64decode |hash('sha1') != local_support_key_check.stat.checksum |default('')
+        - hostvars[groups['shared-infra_hosts'][0]]['support_pub_key'].content |default('') |length > 64
+        - hostvars[groups['shared-infra_hosts'][0]]['support_pub_key'].content |default('') |length > 64
+        - hostvars[groups['shared-infra_hosts'][0]]['support_key'].content |b64decode |hash('sha1') != local_support_key_check.stat.checksum |default('')
   vars_files:
     - "vars/main.yml"


### PR DESCRIPTION
Not all clouds have os-infra_hosts defined.
As the result shared-infra_hosts will be used instead