### PR TITLE
Enable unattended upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Playbooks
 | Name                      | Parameters       |  Description                  |
 |---------------------------|------------------|-------------------------------|
 | archive-control-plane.yml | openstack_release (Optional, used to designate the origin version of the backup) | Archives running OSA managed LXC containers into /openstack/backup/control-plane. Services inside containers will experiences short freeze during archiving |
-| configure-apt.yml | None | Installs openstack-ops APT package dependencies while also turning off unattended APT upgrades |
+| configure-packagemanager.yml | For debian style os, `apt_autoupdate_enabled` can be set as `apt_autoupdate_enabled=1` to enable automatic upgrades moving forward | Installs package dependencies while also configuring automated package update |
 | configure-bash-environment.yml | None | Configures openstack cli bash completion, set vim as default editor and maintain MOTD |
 | configure-cpu-governor.yml | None | Optional, disable CPU ondemand governor and replace it with performance |
 | configure-hosts.yml | ops_host_kernel_modules, ops_host_kernel_sysctl | Load bonding and 8021q modules, enabled IP forwarding |

--- a/playbooks/configure-packagemanager.yml
+++ b/playbooks/configure-packagemanager.yml
@@ -15,21 +15,43 @@
 
 - include: "common-playbooks/register-openstack-release.yml"
 
-- name: Configure apt package manager
+- name: Configure package manager
   hosts: hosts
   environment: "{{ deployment_environment_variables | default({}) }}"
   gather_facts: "{{ gather_facts | default(true) }}"
   pre_tasks:
     - include: "common-tasks/install-dependencies.yml"
   tasks:
-    - name: Configure apt unattended upgrades
+    - name: Update deb selections
+      shell: |
+       echo unattended-upgrades unattended-upgrades/enable_auto_updates boolean {{ apt_autoupdate_enabled |default(0) |bool |lower }} | debconf-set-selections
+      when:
+        - ansible_os_family == 'Debian'
+
+    - name: Configure scope of apt unattended upgrades
       template:
         src: "templates/apt-unattended-upgrades.j2"
         dest: '/etc/apt/apt.conf.d/50unattended-upgrades'
         owner: "root"
         group: "root"
       when: ansible_os_family == 'Debian'
+
+    - name: Configure apt periodic task
+      template:
+        src: "templates/apt-auto-upgrades.j2"
+        dest: '/etc/apt/apt.conf.d/20auto-upgrades'
+        owner: "root"
+        group: "root"
+      when: ansible_os_family == 'Debian'
+
+    - name: Restart unattended upgrade service
+      service:
+        name: unattended-upgrades
+        state: restarted
+        enabled: true
+
   handlers:
     - include: "handlers/main.yml"
   vars_files:
     - "vars/main.yml"
+    - "vars/main-{{ ansible_distribution | lower }}.yml"

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -2,7 +2,7 @@
 #
 # Execute all RPC support playbooks
 #
-- include: configure-apt.yml
+- include: configure-packagemanager.yml
 - include: configure-bash-environment.yml
 - include: configure-hosts.yml
 - include: configure-neutron.yml

--- a/playbooks/templates/apt-auto-upgrades.j2
+++ b/playbooks/templates/apt-auto-upgrades.j2
@@ -1,0 +1,6 @@
+// {{ ansible_managed }}
+
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "{{ apt_autoupdate_interval |default(7) }}";
+APT::Periodic::Unattended-Upgrade "{{ apt_autoupdate_enabled |default(0) }}";

--- a/playbooks/templates/apt-unattended-upgrades.j2
+++ b/playbooks/templates/apt-unattended-upgrades.j2
@@ -2,16 +2,34 @@
 
 // Automatically upgrade packages from these (origin:archive) pairs
 Unattended-Upgrade::Allowed-Origins {
-            //  "${distro_id}:${distro_codename}-security";
-            //  "${distro_id}:${distro_codename}-updates";
-            //  "${distro_id}:${distro_codename}-proposed";
-            //  "${distro_id}:${distro_codename}-backports";
+  "${distro_id}:${distro_codename}-security";
+  //  "${distro_id}:${distro_codename}-updates";
+  //  "${distro_id}:${distro_codename}-proposed";
+  //  "${distro_id}:${distro_codename}-backports";
 };
 
 // List of packages to not update (regexp are supported)
 Unattended-Upgrade::Package-Blacklist {
-        //  "vim";
-        //  "libc6";
-        //  "libc6-dev";
-        //  "libc6-i686";
+{% for package in ops_autoupdate_excluded_packages %}
+  "{{ package }}";
+{% endfor %}
 };
+
+// Do automatic removal of new unused dependencies after the upgrade
+// (equivalent to apt-get autoremove)
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+
+// Automatically reboot *WITHOUT CONFIRMATION*
+//  if the file /var/run/reboot-required is found after the upgrade
+Unattended-Upgrade::Automatic-Reboot "false";
+
+// Send email to this address for problems or packages upgrades
+// If empty or unset then no email is sent, make sure that you
+// have a working mail setup on your system. A package that provides
+// 'mailx' must be installed. E.g. "user@example.com"
+Unattended-Upgrade::Mail "";
+
+// Use apt bandwidth limit feature, this example limits the download
+// speed to 1MB/sec
+Acquire::http::Dl-Limit "1024";
+

--- a/playbooks/vars/main-ubuntu.yml
+++ b/playbooks/vars/main-ubuntu.yml
@@ -1,0 +1,25 @@
+---
+# Copyright 2019-Present, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ops_autoupdate_excluded_packages:
+  - openvswitch-switch
+  - openvswitch-common
+  - open-iscsi
+  - multipath-tools
+  - tgt
+  - ceph
+  - 'ceph-.*'
+  - 'libcephfs*'
+  - python-cephfs

--- a/playbooks/vars/main.yml
+++ b/playbooks/vars/main.yml
@@ -46,6 +46,7 @@ ops_apt_host_packages:
   - vlan
   - python-pip
   - sysfsutils
+  - unattended-upgrades
 
 ops_neutron_debug_packages:
   - iputils-arping
@@ -65,3 +66,4 @@ ops_host_kernel_sysctl:
   - { key: 'net.ipv4.ip_forward', value: 1 }
   - { key: 'net.ipv4.conf.all.rp_filter', value: 0 }
   - { key: 'net.ipv4.conf.default.rp_filter', value: 0 }
+


### PR DESCRIPTION
APT is preconfigured to enable the installation of automated security
upgrade. Packages known to cause instability are exluded via
black listing.
The periodic apt auto update can be enabled with the override
``apt_autoupdate_enabled=1``

This is take #2