### PR TITLE
Updating OSA_RELEASE to 19.0.0 (stein) release

### DIFF
--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -22,7 +22,7 @@
 set -e
 
 OSA_PYEXE=/opt/ansible-runtime/bin/python2.7
-OSA_RELEASE="${OSA_RELEASE:-stable/stein}"
+OSA_RELEASE="${OSA_RELEASE:-19.0.0}"
 OSA_TOKEN_GEN="/opt/openstack-ansible/scripts/pw-token-gen.py"
 OSA_INVENTORY="/opt/openstack-ansible/inventory/dynamic_inventory.py"
 OSA_RUN_PLAY="${OSA_RUN_PLAY:-true}"


### PR DESCRIPTION
The deploy-rpco.sh is updated to deploy the now tagges Stein release