### PR TITLE
Adding support for python3 for OSA 20+ release

### DIFF
--- a/scripts/deploy-rpco.sh
+++ b/scripts/deploy-rpco.sh
@@ -18,16 +18,21 @@
 # 17.x = Queens
 # 18.x = Rocky
 # 19.x = Stein
+# 20.x = Train
 
 set -e
 
-OSA_PYEXE=/opt/ansible-runtime/bin/python2.7
+OSA_PYEXE=/opt/ansible-runtime/bin/python2
 OSA_RELEASE="${OSA_RELEASE:-19.0.10}"
 OSA_TOKEN_GEN="/opt/openstack-ansible/scripts/pw-token-gen.py"
 OSA_INVENTORY="/opt/openstack-ansible/inventory/dynamic_inventory.py"
 OSA_RUN_PLAY="${OSA_RUN_PLAY:-true}"
 ANSIBLE_FORKS=24
 SKIP_PROMPTS="${SKIP_PROMPTS:-false}"
+
+if [ ${OSA_RELEASE%%\.*} -gt 19 ]; then
+  OSA_PYEXE=/opt/ansible-runtime/bin/python3
+fi
 
 test -f ~/.rackspace/datacenter && raxdc="$(cat ~/.rackspace/datacenter |tr '[:upper:]' '[:lower:]')"
 test -d /opt/rpc-config && rpc_config_inplace=true || rpc_config_inplace=false


### PR DESCRIPTION
The deploy-rpco script is now defaulting to python 3 for all
releases after Train