### PR TITLE
Pin setuptools to version 44

### DIFF
--- a/playbooks/common-tasks/install-dependencies.yml
+++ b/playbooks/common-tasks/install-dependencies.yml
@@ -65,8 +65,8 @@
 
 - name: Create virtualenv and upgrade setuptools
   pip:
-    name: setuptools
-    state: latest
+    name: setuptools<45
+    state: present
     extra_args: >-
       --isolated
       {{ pip_install_options|default('') }}


### PR DESCRIPTION
This change pins the version of setuptools to the last functional
python2 version (<45).

Signed-off-by: Nathan Pawelek <nathan.pawelek@rackspace.com>