### PR TITLE
Modify Nova Cleanup script (lessons learned)

### DIFF
--- a/playbooks/files/rpc-o-support/nova-instance-cleanup.sh
+++ b/playbooks/files/rpc-o-support/nova-instance-cleanup.sh
@@ -15,6 +15,8 @@ DELETE FROM nova.instance_system_metadata WHERE instance_uuid IN ( SELECT uuid F
 DELETE FROM nova.instance_extra WHERE instance_uuid IN ( SELECT uuid FROM nova.instances WHERE deleted > 0 );
 DELETE FROM nova.instance_faults WHERE instance_uuid IN ( SELECT uuid FROM nova.instances WHERE deleted > 0 );
 DELETE FROM nova.migrations WHERE instance_uuid IN ( SELECT uuid FROM nova.instances WHERE deleted > 0 );
+DELETE FROM nova_api.request_specs WHERE instance_uuid IN ( SELECT uuid FROM nova.instances WHERE deleted > 0 );
+DELETE FROM nova_api.instance_mappings WHERE instance_uuid IN ( SELECT uuid FROM nova.instances WHERE deleted > 0 );
 
 DROP PROCEDURE IF EXISTS NewtonVifCleanup;
 DELIMITER \$\$


### PR DESCRIPTION
`nova-manage db migration online_data_migrations` failed during upgrade because `nova_api.instance_mappings` had entries for VMs that were deleted in `nova.instances` but not in `nova_api.instance_mappings`. Adding two more cleanup lines related to the `nova_api` database.