### PR TITLE
Modify keyserver variable to facilitate egress firewall workaround

### DIFF
--- a/playbooks/vars/dell-hardware-monitoring.yml
+++ b/playbooks/vars/dell-hardware-monitoring.yml
@@ -19,6 +19,6 @@
 ops_dell_tools_apt_repos:
   - { repo: "deb http://linux.dell.com/repo/community/openmanage/910/{{ ansible_lsb.codename }} {{ ansible_lsb.codename }} main", state: "present", filename: "linux.dell.com.sources" }
 ops_dell_tools_apt_repo_keys:
-  - { keyserver: "pool.sks-keyservers.net", id: "1285491434D8786F", state: "present" }
+  - { keyserver: "hkp://pool.sks-keyservers.net:80", id: "1285491434D8786F", state: "present" }
 ops_dell_tools_monitoring_packages:
   - srvadmin-all


### PR DESCRIPTION
Figure this should be a safe default for adding gpg keys using port 80 instead of the standard hkp port.