### PR TITLE
Adding support for iLO 2.74 on gen9 hpe servers

### DIFF
--- a/playbooks/files/update_hp_firmware.py
+++ b/playbooks/files/update_hp_firmware.py
@@ -108,9 +108,9 @@ firmwares["ProLiant DL360 Gen9"] = {
     },
     "ILO": {
         "check": "hponcfg -h | awk '/Firmware/ {print $4}'",
-        "ver": "2.73",
-        "fwpkg": "hp-firmware-ilo4-2.73-1.1.i386.rpm",
-        "md5": "c436f2200c8341cdb4c44899954038bc",
+        "ver": "2.74",
+        "fwpkg": "firmware-ilo4-2.74-1.1.i386.rpm",
+        "md5": "89e863fecf07ad818f9b148de682ed07",
         "inp": "y\n",
         "ret": 0
     },


### PR DESCRIPTION
Tested on TD server that already has iLO 2.74 installed:
```
root@720473-compute043:~# python /root/update_hp_firmware.py -i
Verified supported hardware: ProLiant DL380 Gen9
Checking for intial pre-requisites...

*********************************************
     INSTALLING REQUIRED UTILITIES ONLY.
*********************************************


Verifying current NIC version: Needs update (5719-v1.46NCSIv1.5.18.0 -> 5719-v1.46NCSIv1.5.12.0)

Verifying current SYSTEM-MELTDOWN version: Already current (v2.76(10/21/2019)P89). Nothing to do.

Verifying current RAID version: Already current (7.00-0). Nothing to do.

Verifying current ILO version: Already current (2.74). Nothing to do.

Verifying current Intel 10G NIC Versions:
 em50 already current. Nothing to do.
 em49 already current. Nothing to do.

SUMMARY: Needs Update
```

Test on lab server that needs iLO update:

- md5 error is likely due to firmware package not being available on cdn

```
root@798606-sbinfra01:~# python ~rack/update_hp_firmware.py -i
Verified supported hardware: ProLiant DL380 Gen9
Checking for intial pre-requisites...

*********************************************
     INSTALLING REQUIRED UTILITIES ONLY.
*********************************************


Verifying current NIC version: Already current (5719-v1.46NCSIv1.5.12.0). Nothing to do.

Verifying current SYSTEM-MELTDOWN version: Already current (v2.76(10/21/2019)P89). Nothing to do.

Verifying current RAID version: Needs update (4.52-0 -> 7.00)

Verifying current ILO version: Needs update (2.73 -> 2.74)

Verifying current Intel 10G NIC Versions:
 em50 already current. Nothing to do.
 em49 already current. Nothing to do.

SUMMARY: Needs Update

root@798606-sbinfra01:~# python ~rack/update_hp_firmware.py -f
Verified supported hardware: ProLiant DL380 Gen9
Checking for intial pre-requisites...
Checking for installation pre-requisites...

Verifying current NIC version: Already current (5719-v1.46NCSIv1.5.12.0). Nothing to do.

Verifying current SYSTEM-MELTDOWN version: Already current (v2.76(10/21/2019)P89). Nothing to do.

Verifying current RAID version: Needs update (4.52-0 -> 7.00)
http://d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com/hp-firmware-smartarray-ea3138d8e8-7.00-1.1.x86_64.rpm
Downloading hp-firmware-smartarray-ea3138d8e8-7.00-1.1.x86_64.rpm  -> Success!
Checking MD5: Match!
Extracting firmware: Success!
Flashing...Success!
Writing log to /root/hpfw-upgrade-2021-01-14-12-42-36/RAID.log

Verifying current ILO version: Needs update (2.73 -> 2.74)
http://d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com/firmware-ilo4-2.74-1.1.i386.rpm
Downloading firmware-ilo4-2.74-1.1.i386.rpm  -> Success!
Checking MD5: Mismatch!  Report this to the author of https://github.com/rcbops/openstack-ops/OWNERS

root@798606-sbinfra01:~# wget http://d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com/firmware-ilo4-2.74-1.1.i386.rpm
--2021-01-14 12:43:51--  http://d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com/firmware-ilo4-2.74-1.1.i386.rpm
Resolving d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com (d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com)... 23.63.240.139, 23.63.240.186, 2600:141b:7000::173f:f0ba, ...
Connecting to d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com (d490e1c1b2bc716e2eaf-63689fefdb0190e2db0220301cd1330e.r14.cf5.rackcdn.com)|23.63.240.139|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2021-01-14 12:43:52 ERROR 404: Not Found.
```

Happy to run some more tests!