### PR TITLE
Update to support 2.80 system firmware on DL380 Gen 9

### DIFF
--- a/playbooks/files/update_hp_firmware.py
+++ b/playbooks/files/update_hp_firmware.py
@@ -84,17 +84,17 @@ firmwares["ProLiant DL360 Gen9"] = {
     },
     "SYSTEM": {
         "check": "hpasmcli -s \"show server\" | grep ROM | cut -d: -f2- | tr -d ' '",
-        "ver": "10/21/2019",
-        "fwpkg": "hp-firmware-system-p89-2.76_2019_10_21-1.1.i386.rpm",
-        "md5": "952e3b3244dd818084fbd09cc3f8c14e",
+        "ver": "10/16/2020",
+        "fwpkg": "hp-firmware-system-p89-2.80_2020_10_16-1.1.i386.rpm",
+        "md5": "386b87b8364f98ae013178324aa86c5e",
         "inp": "y\nn\n",
         "ret": 1
     },
     "SYSTEM-MELTDOWN": {
         "check": "hpasmcli -s \"show server\" | grep ROM | cut -d: -f2- | tr -d ' '",
-        "ver": "10/21/2019",
-        "fwpkg": "hp-firmware-system-p89-2.76_2019_10_21-1.1.i386.rpm",
-        "md5": "952e3b3244dd818084fbd09cc3f8c14e",
+        "ver": "10/16/2020",
+        "fwpkg": "hp-firmware-system-p89-2.80_2020_10_16-1.1.i386.rpm",
+        "md5": "386b87b8364f98ae013178324aa86c5e",
         "inp": "y\nn\n",
         "ret": 1
     },


### PR DESCRIPTION
HPE source: https://support.hpe.com/hpesc/public/swd/detail?swItemId=MTX_a580c721dedc4316afb9399508#tab3

2.80 is on RXT approved firmware list:
https://one.rackspace.com/display/GDCI/Approved+Firmware+List