### PR TITLE
Updating HP ILO firmware

### DIFF
--- a/playbooks/files/update_hp_firmware.py
+++ b/playbooks/files/update_hp_firmware.py
@@ -108,9 +108,9 @@ firmwares["ProLiant DL360 Gen9"] = {
     },
     "ILO": {
         "check": "hponcfg -h | awk '/Firmware/ {print $4}'",
-        "ver": "2.74",
-        "fwpkg": "hp-firmware-ilo4-2.74-1.1.i386.rpm",
-        "md5": "89e863fecf07ad818f9b148de682ed07",
+        "ver": "2.77",
+        "fwpkg": "hp-firmware-ilo4-2.77-1.1.i386.rpm",
+        "md5": "b68558aa595585ea2424a56ffa6c5d93",
         "inp": "y\n",
         "ret": 0
     },
@@ -191,9 +191,9 @@ firmwares["ProLiant DL360 Gen10"] = {
     },
     "ILO": {
         "check": "hponcfg -h | awk '/Firmware/ {print $4}'",
-        "ver": "2.14",
-        "fwpkg": "hp-firmware-ilo5-2.14-1.1.x86_64.rpm",
-        "md5": "5049dcb80f0af9b63ceb5aba051750c2",
+        "ver": "2.42",
+        "fwpkg": "hp-firmware-ilo5-2.42-1.1.x86_64.rpm",
+        "md5": "aba0aa9bbc6659e6d0af269c83f1ecde",
         "inp": "y\n",
         "ret": 0
     },


### PR DESCRIPTION
The HP ilo4/5 firmware is updated to 2020-5