### PR TITLE
Temporarily downgrading hp tools

### DIFF
--- a/playbooks/vars/hp-hardware-monitoring.yml
+++ b/playbooks/vars/hp-hardware-monitoring.yml
@@ -17,7 +17,7 @@
 # HP server utilities
 #
 ops_hp_tools_apt_repos:
-  - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/12.05 non-free", state: "present" }
+  - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/10.80 non-free", state: "present" }
 
 ops_hp_tools_apt_repo_keys:
   - { url: "https://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub", state: "present" }
@@ -27,6 +27,7 @@ ops_hp_tools_apt_firmware_packages:
   - dmidecode
   - ethtool
   - ssacli
+  - hp-health
   - hponcfg
   - ipmitool
   - python3-distro


### PR DESCRIPTION
Until the maas checks are updated, the HP-tools need to remain on 10.80 version.
This locks the tools to Ubuntu 18.04