### PR TITLE
Fix static configurations for holland and hp-tools

### DIFF
--- a/playbooks/install-holland-db-backup.yml
+++ b/playbooks/install-holland-db-backup.yml
@@ -25,6 +25,7 @@
   tasks:
     - name: Create rpc_support backup user
       mysql_user:
+        login_host: "{{ inventory_hostname }}"
         name: "{{ item.name }}"
         host: "{{ item.host }}"
         password: "{{ item.password }}"

--- a/playbooks/templates/holland-mariabackup.conf.j2
+++ b/playbooks/templates/holland-mariabackup.conf.j2
@@ -37,5 +37,5 @@ stream = mbstream
 defaults-extra-file = /root/.my.cnf
 user = rpc_support
 password = {{ rpc_support_holland_password }}
-host = 127.0.0.1
-port = 3306
+host = {{ inventory_hostname }}
+port = {{ galera_port | default(3306) }}

--- a/playbooks/templates/holland-xtrabackup.conf.j2
+++ b/playbooks/templates/holland-xtrabackup.conf.j2
@@ -37,5 +37,5 @@ stream = xbstream
 defaults-extra-file = /root/.my.cnf
 user = rpc_support
 password = {{ rpc_support_holland_password }}
-host = 127.0.0.1
-port = 3306
+host = {{ inventory_hostname }}
+port = {{ galera_port | default(3306) }}

--- a/playbooks/vars/hp-hardware-monitoring.yml
+++ b/playbooks/vars/hp-hardware-monitoring.yml
@@ -16,21 +16,45 @@
 #
 # HP server utilities
 #
-ops_hp_tools_apt_repos:
-  - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/10.80 non-free", state: "present" }
+_ops_hp_tools_apt_repos:
+  trusty:
+    - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/10.62 non-free", state: "present" }
+  xenial:
+    - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/10.80 non-free", state: "present" }
+  bionic:
+    - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/10.80 non-free", state: "present" }
+  focal:
+    - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/12.05 non-free", state: "present" }
+  other:
+    - { repo: "deb http://downloads.linux.hpe.com/SDR/repo/mcp {{ ansible_lsb.codename }}/12.05 non-free", state: "present" }
+
+ops_hp_tools_apt_repos: >
+  {% set _var = [] -%}
+  {% for repo in _ops_hp_tools_apt_repos[ansible_distribution_release] | default(_ops_hp_tools_apt_repos['other']) -%}
+  {%   if _var.append(repo) -%}
+  {%   endif -%}
+  {% endfor -%}
+  {{ _var }}
 
 ops_hp_tools_apt_repo_keys:
   - { url: "https://downloads.linux.hpe.com/SDR/hpePublicKey2048_key1.pub", state: "present" }
 
-ops_hp_tools_apt_firmware_packages:
+ops_hp_tools_apt_firmware_packages_base:
   - rpm2cpio
   - dmidecode
   - ethtool
   - ssacli
-  - hp-health
   - hponcfg
   - ipmitool
   - python3-distro
+
+ops_hp_tools_apt_firmware_packages: >
+  {% set _var = ops_hp_tools_apt_firmware_packages_base -%}
+  {% if ansible_lsb.codename in ['trusty','xenial','bionic'] -%}
+  {%   if _var.append('hp-health') -%}
+  {%   endif -%}
+  {% endif -%}
+  {{ _var }}
 
 ops_hp_tools_monitoring_packages:
   - ssacli


### PR DESCRIPTION
- The HP tools now configre repos appropriate for multiple ubuntu versions

- HP tools with 12.05 removed the HP-health package and the hardware (CPU, Memory)
  can now only be checked via ILO, which requires direct access to the ILO IP.
  As this is usually not given in Rackspace DCs (except newer release like
  Stein+ where we enable Ironic control plane), the hardware checks will
  be moving forward disabled unless maas_ilo_credentials is configured

- Holland now used the OSA configured inventory to address mysqld instead
  of localhost in cases where mysqld listens on br-mgmt or other configured IPs

RPCOS-91 #time 2h Total work logged