### PR TITLE
Conditinally adding hp-health to ops_hp_tools_monitoring_packages

### DIFF
--- a/playbooks/vars/hp-hardware-monitoring.yml
+++ b/playbooks/vars/hp-hardware-monitoring.yml
@@ -56,6 +56,10 @@ ops_hp_tools_apt_firmware_packages: >
   {% endif -%}
   {{ _var }}
 
-ops_hp_tools_monitoring_packages:
-  - ssacli
-  - hponcfg
+ops_hp_tools_monitoring_packages: >
+  {% set _var = ['ssacli','hponcfg'] -%}
+  {% if ansible_lsb.codename in ['trusty','xenial','bionic'] -%}
+  {%   if _var.append('hp-health') -%}
+  {%   endif -%}
+  {% endif -%}
+  {{ _var }}


### PR DESCRIPTION
The hp-health package is available below version 12.x and used to monitor hardware.
After 12.x the ilo needs to be exposed to the hosts and configured appropriately.