### PR TITLE
Update DIB_BOOTLOADER_DEFAULT_CMDLINE to redirect the console to ttyS…

### DIFF
--- a/scripts/build-ironic-images.sh
+++ b/scripts/build-ironic-images.sh
@@ -36,7 +36,7 @@ export ELEMENTS_PATH=/opt/openstack-ops/dib-elements
 
 export COMPRESS_IMAGE='1'
 export DIB_MODPROBE_BLACKLIST='usb-storage cramfs freevxfs jffs2 hfs hfsplus squashfs udf vfat bluetooth'
-export DIB_BOOTLOADER_DEFAULT_CMDLINE='biosdevname=1 net.ifnames=0 rdblacklist=bfa,lpfc nofb nomodeset vga=normal console=tty0 console=ttyS0,115200 audit=1'
+export DIB_BOOTLOADER_DEFAULT_CMDLINE='biosdevname=1 net.ifnames=0 rdblacklist=bfa,lpfc nofb nomodeset vga=normal console=tty0 console=ttyS1,115200n8 audit=1 audit_backlog_limit=8192'
 export DIB_CLOUD_INIT_DATASOURCES="Ec2, ConfigDrive, OpenStack"
 
 #### Disk Image Builder variables (DIB)


### PR DESCRIPTION
…1 and add audit_backlog_limit to supress kauditd errors