### PR TITLE
Prevent named to bind from ipv6 addresses

### DIFF
--- a/playbooks/templates/named.conf.j2
+++ b/playbooks/templates/named.conf.j2
@@ -2,7 +2,8 @@ acl internals { {%- for designate in groups['designate_all'] %} {{hostvars[desig
 acl externals { {{ ops_bind_externals |default('127.0.0.1;') }} };
 
 options {
-        listen-on port 53 { {{ ops_bind_listen }}  };
+        listen-on port 53 { {{ ops_bind_listen }} };
+        listen-on-v6 port 53 { {%- if ops_bind_listen_v6 is defined -%}{{ ops_bind_listen_v6 }}{%- endif -%} };
         directory       "/var/cache/bind";
         dump-file       "/var/cache/bind/data/cache_dump.db";
         statistics-file "/var/cache/bind/data/named_stats.txt";


### PR DESCRIPTION
Unless configured bind(named) will no longer listen to ipv6 and bind to all local ips unless configured.