### PR TITLE
Update consul.yml

### DIFF
--- a/playbooks/vars/consul.yml
+++ b/playbooks/vars/consul.yml
@@ -3,4 +3,4 @@ consul_management_dc_name: 'management'
 consul_cluster_address: "{{ hostvars[inventory_hostname]['ansible_br_mgmt']['ipv4']['address'] }}"
 consul_cluster_interface: "br_mgmt"
 # Masakari Matrix
-masakari_sequence_name: 'management'
+masakari_sequence_name: 'manage'


### PR DESCRIPTION
fixing typo to the sequence name as it has to match the consul variable from masakari-monitors to either "manage", "tenant", or "storage" vars