### PR TITLE
add introspection playbook to add masakari user to libvirt group

### DIFF
--- a/playbooks/handlers/main.yml
+++ b/playbooks/handlers/main.yml
@@ -53,3 +53,8 @@
   service:
     name: masakari-hostmonitor
     state: restarted
+
+- name: Restart Masakari IntrospectionMonitor
+  service:
+    name: masakari-introspectiveinstancemonitor 
+    state: restarted

--- a/playbooks/masakari-introspection-patch.yml
+++ b/playbooks/masakari-introspection-patch.yml
@@ -1,0 +1,19 @@
+---
+#Prevents permission-denied error in Masakari Introspection service from connecting with Libvirt
+
+    - name: Add user masakari to libvirt Group
+      hosts: masakari-monitor_hosts
+      become: yes
+      gather_facts: yes
+      
+      tasks:
+        - name: Add masakari user to libvirt Group
+          user: 
+            name: masakari
+            groups: libvirt
+            append: yes
+          notify: Restart Masakari IntrospectionMonitor 
+
+      handlers:
+        - include: "handlers/main.yml"
+     


### PR DESCRIPTION
adding play to add masakari user to libvirt group on hypervisors to prevent bug, this maybe temporary until an upstream fix is provided.  

error example
22:37:02 compute04 masakari-introspectiveinstancemonitor[98532]: 2024-09-12 03:37:02.612 98532 WARNING masakarimonitors.introspectiveinstancemonitor.instance [-] Error from libvirt : Failed to connect socket to '/var/run/libvirt/libvirt-sock': Permission denied